### PR TITLE
Fix failing examples test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 # Temporary files
 *.tmp
 .temp/
+api/coverage/

--- a/api/test/routes/examples.test.ts
+++ b/api/test/routes/examples.test.ts
@@ -152,11 +152,11 @@ describe('Examples API Route', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readdirSync as jest.Mock).mockReturnValue(['valid.json', 'invalid.json']);
       (fs.readFileSync as jest.Mock).mockImplementation((filePath: string) => {
-        if (filePath.includes('valid.json')) {
-          return JSON.stringify(validExample);
-        }
-        if (filePath.includes('invalid.json')) {
+        if (filePath.endsWith('invalid.json')) {
           return '{invalid json';
+        }
+        if (filePath.endsWith('valid.json')) {
+          return JSON.stringify(validExample);
         }
         throw new Error('Unknown file');
       });


### PR DESCRIPTION
## Summary

Fixes failing test in `api/test/routes/examples.test.ts` that was expecting 1 example but getting 2.

## Root Cause

The test mock was using `.includes()` to check file paths:
```javascript
if (filePath.includes('valid.json'))  // Bug!
```

This caused `"valid.json"` to match both `"valid.json"` **and** `"invalid.json"` because `"valid.json"` is a substring of `"invalid.json"`. Both files were returning valid JSON, so 2 valid examples were loaded instead of 1.

## Fix

Changed to use `.endsWith()` and check `invalid.json` first:
```javascript
if (filePath.endsWith('invalid.json')) {
  return '{invalid json';
}
if (filePath.endsWith('valid.json')) {
  return JSON.stringify(validExample);
}
```

## Test Results

```
PASS test/routes/examples.test.ts
  Examples API Route
    GET /api/examples
      ✓ should return list of example templates
      ✓ should return empty array if no examples exist
      ✓ should filter out non-JSON files
      ✓ should handle file read errors gracefully
      ✓ should handle invalid JSON gracefully  ← Fixed!
      ✓ should validate example structure
      ✓ should load examples for multiple SDK types
    GET /api/examples/:id
      ✓ should return specific example by id
      ✓ should return 404 if example not found

Test Suites: 1 passed
Tests:       9 passed
```

## Additional Changes

- Added `api/coverage/` to `.gitignore` to prevent committing coverage reports

Closes #35