### PR TITLE
Add Secure Configuration Sharing Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,28 @@ See **[Diff Viewer Guide](docs/diff-viewer.md)** for details.
 
 Copy your tested `beforeSend` code to your Sentry SDK configuration.
 
+## Sharing Configurations
+
+You can safely share your beforeSend configurations with colleagues:
+
+1. Configure your event JSON and beforeSend code
+2. Click the "Share" button (right side of controls)
+3. A paste will be created with your configuration (expires after 30 days)
+4. Copy the URL and share it with others
+
+**Security**: Event values are automatically scrubbed before sharing to prevent accidental PII leakage. Only the event structure (field names and types) is shared, along with your beforeSend code. For example:
+```json
+{
+  "user": {
+    "email": "<string>",
+    "ip_address": "<string>"
+  },
+  "exception": {
+    "values": [...]
+  }
+}
+```
+
 ## Real-World Example
 
 **Problem:** Android Unity crashes include device metadata in the exception message, making issue titles unreadable.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import transformRouter from './routes/transform';
 import examplesRouter from './routes/examples';
 import validateRouter from './routes/validate';
+import shareRouter from './routes/share';
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -33,6 +34,7 @@ app.get('/health', (req, res) => {
 app.use('/api/transform', transformRouter);
 app.use('/api/examples', examplesRouter);
 app.use('/api/validate', validateRouter);
+app.use('/api/share', shareRouter);
 
 // 404 handler
 app.use((req, res) => {

--- a/api/src/routes/share.ts
+++ b/api/src/routes/share.ts
@@ -1,0 +1,118 @@
+import express from 'express';
+import axios from 'axios';
+
+const router = express.Router();
+
+interface ShareRequest {
+  sdk: string;
+  sdkName: string;
+  sdkPackage: string;
+  sdkVersion: string;
+  event: Record<string, any>;
+  beforeSendCode: string;
+}
+
+/**
+ * Recursively scrub an event object to show structure only
+ * Replaces all values with placeholders to prevent PII leakage
+ */
+function scrubEventData(obj: any, depth = 0): any {
+  // Prevent infinite recursion
+  if (depth > 10) {
+    return '[MAX_DEPTH_REACHED]';
+  }
+
+  if (obj === null) {
+    return null;
+  }
+
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) {
+      return [];
+    }
+    // Show structure of first item, indicate array
+    return [scrubEventData(obj[0], depth + 1), '...'];
+  }
+
+  if (typeof obj === 'object') {
+    const scrubbed: Record<string, any> = {};
+    for (const key in obj) {
+      scrubbed[key] = scrubEventData(obj[key], depth + 1);
+    }
+    return scrubbed;
+  }
+
+  // Replace primitive values with type indicators
+  if (typeof obj === 'string') {
+    return `<string>`;
+  }
+  if (typeof obj === 'number') {
+    return `<number>`;
+  }
+  if (typeof obj === 'boolean') {
+    return `<boolean>`;
+  }
+
+  return `<${typeof obj}>`;
+}
+
+router.post('/', async (req, res) => {
+  try {
+    const { sdk, sdkName, sdkPackage, sdkVersion, event, beforeSendCode } = req.body as ShareRequest;
+
+    if (!sdk || !event || !beforeSendCode) {
+      return res.status(400).json({
+        error: 'Missing required fields: sdk, event, beforeSendCode',
+      });
+    }
+
+    // Scrub event data to prevent PII leakage
+    const scrubbedEvent = scrubEventData(event);
+
+    // Create readable paste content
+    const content = `# SDK: ${sdkName} (${sdkPackage} ${sdkVersion})
+
+# ==================== Event Structure ====================
+# NOTE: Original values have been removed to prevent accidental PII sharing.
+# Only the event structure is shown below.
+
+${JSON.stringify(scrubbedEvent, null, 2)}
+
+# ==================== beforeSend Code ====================
+${beforeSendCode}`;
+
+    // Create paste via dpaste.com (no authentication required)
+    const formData = new URLSearchParams();
+    formData.append('content', content);
+    formData.append('syntax', 'text'); // Plain text for better readability
+    formData.append('expiry_days', '30'); // Expire after 30 days
+
+    const response = await axios.post(
+      'https://dpaste.com/api/',
+      formData,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: 10000,
+      }
+    );
+
+    // dpaste returns the URL as plain text with .txt extension
+    // Remove .txt to get the HTML view
+    const pasteUrl = response.data.trim().replace(/\.txt$/, '');
+
+    res.json({
+      html_url: pasteUrl,
+      id: pasteUrl.split('/').pop(),
+    });
+  } catch (error: any) {
+    console.error('Failed to create paste:', error.response?.data || error.message);
+    res.status(500).json({
+      error: 'Failed to create paste',
+      message: error.response?.data?.message || error.message,
+    });
+  }
+});
+
+export default router;

--- a/api/test/routes/share.test.ts
+++ b/api/test/routes/share.test.ts
@@ -1,0 +1,348 @@
+import request from 'supertest';
+import express from 'express';
+import shareRouter from '../../src/routes/share';
+import axios from 'axios';
+
+// Mock axios to avoid actual API calls
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const app = express();
+app.use(express.json());
+app.use('/api/share', shareRouter);
+
+describe('Share Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/share', () => {
+    it('should create a share link successfully', async () => {
+      // Mock dpaste response
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/ABC123DEF.txt',
+      });
+
+      const response = await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: {
+            event_id: 'test-123',
+            exception: {
+              values: [{
+                type: 'Error',
+                value: 'Test error',
+              }],
+            },
+          },
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('html_url');
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.html_url).toBe('https://dpaste.com/ABC123DEF');
+      expect(response.body.id).toBe('ABC123DEF');
+    });
+
+    it('should return 400 if sdk is missing', async () => {
+      const response = await request(app)
+        .post('/api/share')
+        .send({
+          event: { event_id: 'test' },
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Missing required fields');
+    });
+
+    it('should return 400 if event is missing', async () => {
+      const response = await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Missing required fields');
+    });
+
+    it('should return 400 if beforeSendCode is missing', async () => {
+      const response = await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: { event_id: 'test' },
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Missing required fields');
+    });
+
+    it('should scrub sensitive data from event', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/SCRUBTEST.txt',
+      });
+
+      const sensitiveEvent = {
+        event_id: 'a1b2c3d4',
+        user: {
+          id: '12345',
+          email: 'user@example.com',
+          ip_address: '192.168.1.100',
+        },
+        exception: {
+          values: [{
+            type: 'ValueError',
+            value: 'Credit card 4532-1234-5678-9010 is invalid',
+          }],
+        },
+        extra: {
+          api_key: 'sk_live_secret123',
+          session_token: 'eyJhbGc...',
+        },
+      };
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: sensitiveEvent,
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      // Verify axios was called with scrubbed content
+      expect(mockedAxios.post).toHaveBeenCalled();
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      // Verify sensitive data is NOT in the content
+      expect(content).not.toContain('user@example.com');
+      expect(content).not.toContain('192.168.1.100');
+      expect(content).not.toContain('4532-1234-5678-9010');
+      expect(content).not.toContain('sk_live_secret123');
+      expect(content).not.toContain('eyJhbGc...');
+
+      // Verify structure indicators ARE in the content
+      expect(content).toContain('<string>');
+      expect(content).toContain('user');
+      expect(content).toContain('email');
+      expect(content).toContain('ip_address');
+      expect(content).toContain('api_key');
+    });
+
+    it('should include SDK information in paste', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/SDKTEST.txt',
+      });
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'python',
+          sdkName: 'Python',
+          sdkPackage: 'sentry-sdk',
+          sdkVersion: '2.20.0',
+          event: { event_id: 'test' },
+          beforeSendCode: 'def before_send(event, hint):\n  return event',
+        })
+        .set('Content-Type', 'application/json');
+
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      expect(content).toContain('SDK: Python');
+      expect(content).toContain('sentry-sdk 2.20.0');
+    });
+
+    it('should include beforeSend code unchanged', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/CODETEST.txt',
+      });
+
+      const beforeSendCode = `(event, hint) => {
+  // Custom transformation
+  event.tags = { ...event.tags, custom: 'value' };
+  return event;
+}`;
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: { event_id: 'test' },
+          beforeSendCode,
+        })
+        .set('Content-Type', 'application/json');
+
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      expect(content).toContain(beforeSendCode);
+      expect(content).toContain('Custom transformation');
+    });
+
+    it('should handle dpaste API errors gracefully', async () => {
+      mockedAxios.post.mockRejectedValue({
+        response: {
+          data: { message: 'dpaste service unavailable' },
+        },
+      });
+
+      const response = await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: { event_id: 'test' },
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe('Failed to create paste');
+    });
+
+    it('should scrub arrays correctly', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/ARRAYTEST.txt',
+      });
+
+      const eventWithArrays = {
+        exception: {
+          values: [
+            { type: 'Error1', value: 'Message 1' },
+            { type: 'Error2', value: 'Message 2' },
+          ],
+        },
+        breadcrumbs: [
+          { message: 'Breadcrumb 1', timestamp: 123456 },
+          { message: 'Breadcrumb 2', timestamp: 123457 },
+        ],
+      };
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: eventWithArrays,
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      // Arrays should show structure of first item + "..."
+      expect(content).toContain('"..."');
+      expect(content).not.toContain('Message 1');
+      expect(content).not.toContain('Message 2');
+      expect(content).not.toContain('Breadcrumb 1');
+    });
+
+    it('should scrub nested objects correctly', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/NESTEDTEST.txt',
+      });
+
+      const eventWithNested = {
+        contexts: {
+          app: {
+            app_name: 'MyApp',
+            app_version: '1.0.0',
+          },
+          device: {
+            model: 'iPhone 12',
+            os: 'iOS 15.0',
+          },
+        },
+      };
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: eventWithNested,
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      // Structure should be preserved
+      expect(content).toContain('contexts');
+      expect(content).toContain('app');
+      expect(content).toContain('device');
+      expect(content).toContain('app_name');
+      expect(content).toContain('model');
+
+      // Values should be scrubbed
+      expect(content).not.toContain('MyApp');
+      expect(content).not.toContain('1.0.0');
+      expect(content).not.toContain('iPhone 12');
+      expect(content).not.toContain('iOS 15.0');
+      expect(content).toContain('<string>');
+    });
+
+    it('should include PII warning in paste content', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: 'https://dpaste.com/WARNING.txt',
+      });
+
+      await request(app)
+        .post('/api/share')
+        .send({
+          sdk: 'javascript',
+          sdkName: 'JavaScript',
+          sdkPackage: '@sentry/node',
+          sdkVersion: '8.55.0',
+          event: { event_id: 'test' },
+          beforeSendCode: '(event) => event',
+        })
+        .set('Content-Type', 'application/json');
+
+      const callArgs = mockedAxios.post.mock.calls[0];
+      const formData = callArgs[1] as URLSearchParams;
+      const content = formData.get('content');
+
+      expect(content).toContain('NOTE: Original values have been removed to prevent accidental PII sharing');
+    });
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,9 @@ The beforeSend Testing Playground uses a microservices architecture with Docker 
 **Key Endpoints:**
 - `POST /api/transform` - Transform events
 - `GET /api/transform/sdks` - List SDKs
+- `POST /api/share` - Create shareable paste link (dpaste.com)
+- `GET /api/examples` - Get example configurations
+- `POST /api/validate` - Validate beforeSend code syntax
 - `GET /health` - Health check
 
 ### SDK Containers

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -58,6 +58,20 @@ export interface ValidationResponse {
   errors: ValidationError[];
 }
 
+export interface ShareRequest {
+  sdk: string;
+  sdkName: string;
+  sdkPackage: string;
+  sdkVersion: string;
+  event: Record<string, any>;
+  beforeSendCode: string;
+}
+
+export interface ShareResponse {
+  html_url: string;
+  id: string;
+}
+
 export const apiClient = {
   async transform(request: TransformRequest): Promise<TransformResponse> {
     const response = await axios.post<TransformResponse>(
@@ -94,6 +108,21 @@ export const apiClient = {
         timeout: 5000, // 5 second timeout for validation
       }
     );
+    return response.data;
+  },
+
+  async createAnonymousGist(request: ShareRequest): Promise<ShareResponse> {
+    const response = await axios.post<ShareResponse>(
+      `${API_URL}/api/share`,
+      request,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 10000, // 10 second timeout
+      }
+    );
+
     return response.data;
   },
 };


### PR DESCRIPTION
## Summary

Adds a \"Share\" button that creates shareable paste links for beforeSend configurations using dpaste.com.

**Key Features:**
- ✅ Automatic PII scrubbing - Event values replaced with type indicators (`<string>`, `<number>`)
- ✅ Structure preservation - Field names and types preserved for context
- ✅ beforeSend code shared unchanged for collaboration
- ✅ No authentication required - Uses dpaste.com (30-day expiry)
- ✅ Clean UI - Right-aligned "Share" button with modal feedback
- ✅ Comprehensive tests - 11 test cases, all passing

## Security

All sensitive data is automatically scrubbed before sharing:
- Strings: `"user@example.com"` → `<string>`
- Numbers: `192.168.1.100` → `<number>`
- Nested objects/arrays: Recursively scrubbed
- Clear warnings in UI and paste content

## Example

**Before (Original):**
```json
{
  "user": {
    "email": "user@example.com",
    "ip_address": "192.168.1.100"
  }
}
```

**After (Shared):**
```json
{
  "user": {
    "email": "<string>",
    "ip_address": "<string>"
  }
}
```

## Testing

```bash
# Run tests
docker run --rm beforesend-playground-api npm test -- share.test.ts

# All 11 tests pass ✓
```

## Documentation

- ✅ README.md updated with usage instructions
- ✅ Architecture docs updated with new endpoint
- ✅ Inline code comments and JSDoc

## Changes

- `api/src/routes/share.ts` - New share endpoint with scrubbing logic
- `api/test/routes/share.test.ts` - Comprehensive test suite (11 tests)
- `ui/src/App.tsx` - Share button and modal UI
- `ui/src/api/client.ts` - API client for share endpoint
- `README.md` - Usage instructions and security info
- `docs/architecture.md` - Updated endpoint list

🤖 Generated with Claude Code