### PR TITLE
Clarify users can write custom code in README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-**Learn by doing.** The beforeSend Testing Playground lets you experiment with real Sentry SDKs in a safe sandbox environment. Load pre-built examples, see transformations in action with visual diffs, share configurations securely, and master `beforeSend` patterns across 11 languages—all before touching production. Perfect for Solutions Engineers impressing customers with live demos and building deep SDK expertise.
+**Learn by doing.** The beforeSend Testing Playground lets you experiment with real Sentry SDKs in a safe sandbox environment. Load pre-built examples or write your own code, see transformations in action with visual diffs, share configurations securely, and master `beforeSend` patterns across 11 languages—all before touching production. Perfect for Solutions Engineers impressing customers with live demos and building deep SDK expertise.
 
 **Key Features:**
 - ✅ Test with real Sentry SDKs (JavaScript, Python, Ruby, PHP, Go, .NET, Java, Android, Cocoa, Rust, **Elixir**)


### PR DESCRIPTION
## Summary

Minor documentation improvement to clarify that users can either load pre-built examples OR write their own custom code.

## Changes

Updated the overview paragraph:

**Before:**
> Load pre-built examples, see transformations in action...

**After:**
> Load pre-built examples **or write your own code**, see transformations in action...

## Why This Change?

The current phrasing only mentions loading examples, which might give users the impression that custom code isn't supported. This small change clarifies both options:

1. 📦 Load pre-built examples (easier starting point)
2. ✍️ Write your own code from scratch (full flexibility)

This is especially important for Solutions Engineers who often need to write custom beforeSend logic for customer demos.

## Related

- Follow-up to #46 (sharing feature)
- Follow-up to #47 (sharing documentation)

🤖 Generated with Claude Code