### PR TITLE
fix(examples): enhance Unity cleanup to extract metadata into tags

### DIFF
--- a/api/examples/unity-cleanup.json
+++ b/api/examples/unity-cleanup.json
@@ -1,8 +1,10 @@
 {
   "id": "unity-cleanup",
   "name": "Unity Metadata Cleanup",
-  "description": "Extract actual exception from Unity/Android crash metadata that pollutes exception messages, making issue titles unreadable",
+  "description": "Extract device metadata from messy Unity/Android crash titles into searchable tags, then parse the actual exception for a clean issue title",
+  "type": "fingerprinting",
   "sdk": "javascript",
+  "complexity": "intermediate",
   "event": {
     "event_id": "4ac65cab-f83d-4727-b1c5-82a35f9a31d3",
     "timestamp": "2026-01-22T12:30:00.000Z",
@@ -17,5 +19,5 @@
       ]
     }
   },
-  "beforeSendCode": "(event, hint) => {\n  if (event.exception && event.exception.values) {\n    for (const exception of event.exception.values) {\n      // Check if metadata is polluting the exception value\n      if (exception.value &&\n          (exception.value.includes('Unity version') ||\n           exception.value.includes('Device model') ||\n           exception.value.includes('Device fingerprint'))) {\n\n        // Extract thread name\n        const threadMatch = exception.value.match(/\\[([^\\]]+)\\]/);\n        if (threadMatch) {\n          event.tags = { ...event.tags, thread: threadMatch[1] };\n        }\n\n        // Extract actual exception type using regex\n        const exceptionMatch = exception.value.match(/([\\w\\.$]+(?:Exception|Error)):\\s*([^\\n]+?)\\s*$/);\n\n        if (exceptionMatch) {\n          // Found the real exception - use it\n          exception.type = exceptionMatch[1];\n          exception.value = exceptionMatch[2];\n        } else {\n          // No exception found - use generic but descriptive title\n          exception.type = 'NativeCrash';\n          exception.value = 'Android Native Crash';\n        }\n      }\n    }\n  }\n\n  return event;\n}"
+  "beforeSendCode": "(event, hint) => {\n  if (!event.exception?.values) return event;\n\n  for (const exception of event.exception.values) {\n    const val = exception.value || '';\n    \n    // Only process Unity metadata dumps\n    if (!val.includes('Unity version')) continue;\n\n    // Store original for debugging\n    event.extra = { ...event.extra, original_exception: val };\n    event.tags = event.tags || {};\n\n    // Extract metadata into searchable tags\n    const patterns = {\n      'thread': /\\[([^\\]]+)\\]/,\n      'unity.version': /Unity version\\s*:\\s*([\\d.]+\\w*)/,\n      'device.model': /Device model\\s*:\\s*([^\\s]+\\s+[^\\s]+)/,\n      'device.abi': /CPU supported ABI\\s*:\\s*\\[([^\\]]+)\\]/,\n      'unity.build_type': /Build Type\\s*:\\s*(\\w+)/,\n      'unity.scripting_backend': /Scripting Backend\\s*:\\s*(\\w+)/\n    };\n\n    for (const [tag, regex] of Object.entries(patterns)) {\n      const match = val.match(regex);\n      if (match) event.tags[tag] = match[1].trim();\n    }\n\n    // Extract the actual exception (usually at the end)\n    const exceptionMatch = val.match(/([\\w.$]+(?:Exception|Error)):\\s*(.+?)\\s*$/);\n    if (exceptionMatch) {\n      exception.type = exceptionMatch[1];\n      exception.value = exceptionMatch[2];\n    } else {\n      exception.type = 'NativeCrash';\n      exception.value = 'Android Native Crash';\n    }\n  }\n\n  return event;\n}"
 }


### PR DESCRIPTION
## Summary
- Extract Unity metadata (version, device model, ABI, build type, scripting backend) into searchable tags instead of discarding
- Store original exception value in `extra.original_exception` for debugging
- Add `type: "fingerprinting"` so example appears in Fingerprinting playground
- Cleaner code structure with pattern-based extraction

## Before
The example just cleaned up the title and discarded the metadata.

## After
Metadata is extracted into tags like:
- `unity.version: "6000.2.14f1"`
- `device.model: "samsung SM-A022M"`
- `device.abi: "armeabi-v7a, armeabi"`
- `unity.build_type: "Release"`
- `unity.scripting_backend: "IL2CPP"`
- `thread: "RxComputationThreadPool-1"`

This makes the data searchable/filterable in Sentry while keeping issue titles clean.

---
Generated with [Claude Code](https://claude.com/claude-code)