### PR TITLE
fix(examples): move Unity cleanup to beforeSend type

### DIFF
--- a/api/examples/unity-cleanup.json
+++ b/api/examples/unity-cleanup.json
@@ -2,7 +2,7 @@
   "id": "unity-cleanup",
   "name": "Unity Metadata Cleanup",
   "description": "Extract device metadata from messy Unity/Android crash titles into searchable tags, then parse the actual exception for a clean issue title",
-  "type": "fingerprinting",
+  "type": "beforeSend",
   "sdk": "javascript",
   "complexity": "intermediate",
   "event": {


### PR DESCRIPTION
The example is about data extraction/transformation (cleaning titles, extracting metadata to tags), not fingerprinting. It doesn't set `event.fingerprint`, so `beforeSend` is the more appropriate type.