### PR TITLE
fix(examples): add missing type field to 18 examples

### DIFF
--- a/api/examples/add-custom-context.json
+++ b/api/examples/add-custom-context.json
@@ -2,6 +2,7 @@
   "id": "add-custom-context",
   "name": "Add Custom Tags & Context",
   "description": "Enrich events with custom tags, extra context, and metadata for better filtering and debugging",
+  "type": "beforeSend",
   "sdk": "javascript",
   "event": {
     "event_id": "context-test-789",

--- a/api/examples/add-custom-tags-cocoa.json
+++ b/api/examples/add-custom-tags-cocoa.json
@@ -2,6 +2,7 @@
   "id": "add-custom-tags-cocoa",
   "name": "Add Custom Tags & Context (Cocoa)",
   "description": "Enrich iOS/macOS events with mobile-specific tags, device info, and app context for better debugging",
+  "type": "beforeSend",
   "sdk": "cocoa",
   "event": {
     "event_id": "cocoa-context-777",

--- a/api/examples/add-custom-tags-java.json
+++ b/api/examples/add-custom-tags-java.json
@@ -2,6 +2,7 @@
   "id": "add-custom-tags-java",
   "name": "Add Custom Tags & Context (Java)",
   "description": "Enrich Java backend events with custom tags, business context, and request metadata for better filtering and debugging",
+  "type": "beforeSend",
   "sdk": "java",
   "event": {
     "event_id": "java-context-555",

--- a/api/examples/android-context-enrichment.json
+++ b/api/examples/android-context-enrichment.json
@@ -2,6 +2,7 @@
   "id": "android-context-enrichment",
   "name": "Android Context Enrichment",
   "description": "Add Android-specific device context (battery, network, orientation, memory) to events for mobile debugging",
+  "type": "beforeSend",
   "sdk": "android",
   "event": {
     "event_id": "android-context-888",

--- a/api/examples/aspnet-request-context.json
+++ b/api/examples/aspnet-request-context.json
@@ -2,6 +2,7 @@
   "id": "aspnet-request-context",
   "name": "ASP.NET Request Context",
   "description": "Enrich .NET backend events with ASP.NET-specific request context (controller, action, route data, claims)",
+  "type": "beforeSend",
   "sdk": "dotnet",
   "event": {
     "event_id": "aspnet-context-999",

--- a/api/examples/conditional-dropping-go.json
+++ b/api/examples/conditional-dropping-go.json
@@ -2,6 +2,7 @@
   "id": "conditional-dropping-go",
   "name": "Conditional Event Dropping (Go)",
   "description": "Filter out noisy errors in Go services - health checks, known errors, development environments",
+  "type": "beforeSend",
   "sdk": "go",
   "event": {
     "event_id": "go-drop-321",

--- a/api/examples/conditional-dropping-php.json
+++ b/api/examples/conditional-dropping-php.json
@@ -2,6 +2,7 @@
   "id": "conditional-dropping-php",
   "name": "Conditional Event Dropping (PHP)",
   "description": "Filter out noisy or irrelevant errors in PHP applications - bots, third-party scripts, test users",
+  "type": "beforeSend",
   "sdk": "php",
   "event": {
     "event_id": "php-drop-789",

--- a/api/examples/conditional-dropping-rust.json
+++ b/api/examples/conditional-dropping-rust.json
@@ -2,6 +2,7 @@
   "id": "conditional-dropping-rust",
   "name": "Conditional Event Dropping (Rust)",
   "description": "Filter out noisy errors in Rust services - health checks, test environments, and specific error types",
+  "type": "beforeSend",
   "sdk": "rust",
   "event": {
     "event_id": "rust-drop-123",

--- a/api/examples/conditional-event-dropping.json
+++ b/api/examples/conditional-event-dropping.json
@@ -2,6 +2,7 @@
   "id": "conditional-event-dropping",
   "name": "Conditional Event Dropping",
   "description": "Filter out noisy or irrelevant errors before sending them to Sentry to reduce quota usage",
+  "type": "beforeSend",
   "sdk": "javascript",
   "event": {
     "event_id": "drop-test-101",

--- a/api/examples/custom-fingerprinting.json
+++ b/api/examples/custom-fingerprinting.json
@@ -2,6 +2,7 @@
   "id": "custom-fingerprinting",
   "name": "Custom Fingerprinting",
   "description": "Group similar errors together by customizing the fingerprint, useful for dynamic error messages with unique IDs",
+  "type": "fingerprinting",
   "sdk": "javascript",
   "event": {
     "event_id": "fingerprint-test-456",

--- a/api/examples/go-service-metadata.json
+++ b/api/examples/go-service-metadata.json
@@ -2,6 +2,7 @@
   "id": "go-service-metadata",
   "name": "Go Service Metadata & Infrastructure",
   "description": "Add Go microservice context (service name, version, deployment, Kubernetes pod info) for distributed systems debugging",
+  "type": "beforeSend",
   "sdk": "go",
   "event": {
     "event_id": "go-service-222",

--- a/api/examples/ios-lifecycle-tags.json
+++ b/api/examples/ios-lifecycle-tags.json
@@ -2,6 +2,7 @@
   "id": "ios-lifecycle-tags",
   "name": "iOS Lifecycle & App State Tags",
   "description": "Add iOS-specific lifecycle events, memory warnings, and app state transition context for mobile debugging",
+  "type": "beforeSend",
   "sdk": "cocoa",
   "event": {
     "event_id": "ios-lifecycle-111",

--- a/api/examples/pii-scrubbing-dotnet.json
+++ b/api/examples/pii-scrubbing-dotnet.json
@@ -2,6 +2,7 @@
   "id": "pii-scrubbing-dotnet",
   "name": "PII Scrubbing (.NET)",
   "description": "Remove personally identifiable information (emails, phone numbers, SSNs) from .NET events using C# regex patterns",
+  "type": "beforeSend",
   "sdk": "dotnet",
   "event": {
     "event_id": "dotnet-pii-123",

--- a/api/examples/pii-scrubbing-python.json
+++ b/api/examples/pii-scrubbing-python.json
@@ -2,6 +2,7 @@
   "id": "pii-scrubbing-python",
   "name": "PII Scrubbing (Python)",
   "description": "Remove personally identifiable information from Python events using Python beforeSend callback",
+  "type": "beforeSend",
   "sdk": "python",
   "event": {
     "event_id": "python-pii-123",

--- a/api/examples/pii-scrubbing-ruby.json
+++ b/api/examples/pii-scrubbing-ruby.json
@@ -2,6 +2,7 @@
   "id": "pii-scrubbing-ruby",
   "name": "PII Scrubbing (Ruby)",
   "description": "Remove personally identifiable information (emails, phone numbers, SSNs) from Ruby events using regex patterns",
+  "type": "beforeSend",
   "sdk": "ruby",
   "event": {
     "event_id": "ruby-pii-456",

--- a/api/examples/pii-scrubbing-rust.json
+++ b/api/examples/pii-scrubbing-rust.json
@@ -2,6 +2,7 @@
   "id": "pii-scrubbing-rust",
   "name": "PII Scrubbing (Rust)",
   "description": "Remove sensitive data (emails, API keys, tokens) from Rust error events before sending to Sentry",
+  "type": "beforeSend",
   "sdk": "rust",
   "event": {
     "event_id": "rust-pii-456",

--- a/api/examples/pii-scrubbing.json
+++ b/api/examples/pii-scrubbing.json
@@ -2,6 +2,7 @@
   "id": "pii-scrubbing",
   "name": "PII Scrubbing",
   "description": "Remove personally identifiable information (emails, phone numbers, SSNs) from events before sending to Sentry",
+  "type": "beforeSend",
   "sdk": "javascript",
   "event": {
     "event_id": "test-pii-123",

--- a/api/examples/rust-service-metadata.json
+++ b/api/examples/rust-service-metadata.json
@@ -2,6 +2,7 @@
   "id": "rust-service-metadata",
   "name": "Service Metadata Enrichment (Rust)",
   "description": "Add service version, build info, and deployment context to Rust error events",
+  "type": "beforeSend",
   "sdk": "rust",
   "event": {
     "event_id": "rust-meta-789",


### PR DESCRIPTION
## Summary
18 examples were missing the `type` field, so they weren't showing up in any playground mode.

### Changes
- 17 examples → `type: "beforeSend"` (general event transformation)
- 1 example (custom-fingerprinting) → `type: "fingerprinting"` (sets event.fingerprint)

### Files updated
- add-custom-context.json
- add-custom-tags-cocoa.json
- add-custom-tags-java.json
- android-context-enrichment.json
- aspnet-request-context.json
- conditional-dropping-go.json
- conditional-dropping-php.json
- conditional-dropping-rust.json
- conditional-event-dropping.json
- custom-fingerprinting.json
- go-service-metadata.json
- ios-lifecycle-tags.json
- pii-scrubbing-dotnet.json
- pii-scrubbing-python.json
- pii-scrubbing-ruby.json
- pii-scrubbing-rust.json
- pii-scrubbing.json
- rust-service-metadata.json