### PR TITLE
fix(api): add fingerprinting type to examples filter

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -29,7 +29,7 @@ export interface SDKsResponse {
   sdks: SDK[];
 }
 
-export type ExampleType = 'beforeSend' | 'beforeSendTransaction' | 'beforeBreadcrumb' | 'tracesSampler';
+export type ExampleType = 'beforeSend' | 'fingerprinting' | 'beforeSendTransaction' | 'beforeBreadcrumb' | 'tracesSampler';
 
 export interface Example {
   id: string;


### PR DESCRIPTION
The API route was missing 'fingerprinting' as a valid type filter, causing all examples to be returned when `type=fingerprinting` was requested.

## Changes
- Add `fingerprinting` to Example type definition
- Add `fingerprinting` to valid types array for filtering
- Add validation check for fingerprinting examples
- Refactor type check to use array for easier maintenance