### PR TITLE
fix(examples): add missing id field to fingerprinting examples

### DIFF
--- a/api/examples/normalize-api-urls-javascript.json
+++ b/api/examples/normalize-api-urls-javascript.json
@@ -1,4 +1,5 @@
 {
+  "id": "normalize-api-urls",
   "name": "Normalize API URL Errors",
   "description": "Group API errors by endpoint pattern, ignoring dynamic IDs",
   "type": "fingerprinting",

--- a/api/examples/normalize-db-errors-javascript.json
+++ b/api/examples/normalize-db-errors-javascript.json
@@ -1,4 +1,5 @@
 {
+  "id": "normalize-db-errors",
   "name": "Normalize Database Errors",
   "description": "Group all database connection errors together regardless of instance",
   "type": "fingerprinting",

--- a/api/examples/split-by-user-type-javascript.json
+++ b/api/examples/split-by-user-type-javascript.json
@@ -1,4 +1,5 @@
 {
+  "id": "split-by-user-type",
   "name": "Split by User Type",
   "description": "Create separate issues for free vs premium user errors",
   "type": "fingerprinting",


### PR DESCRIPTION
Three fingerprinting examples were missing the required 'id' field, causing them to fail validation and not appear in the Fingerprinting playground.