### PR TITLE
Strip Unicode PUA characters from parsed Sentry URLs

### DIFF
--- a/api/src/routes/sentry-query.ts
+++ b/api/src/routes/sentry-query.ts
@@ -256,7 +256,10 @@ router.post('/parse-url', (req: Request, res: Response) => {
     }
 
     // Extract query parameters
-    const query = parsedUrl.searchParams.get('query') || undefined;
+    // Strip Unicode Private Use Area characters (U+E000-U+F8FF) that Sentry UI uses for formatting
+    // These characters appear in URLs like %EF%80%8D (U+F00D) and can cause display/parsing issues
+    const rawQuery = parsedUrl.searchParams.get('query');
+    const query = rawQuery ? rawQuery.replace(/[\uE000-\uF8FF]/g, '') : undefined;
     const environment = parsedUrl.searchParams.get('environment') || undefined;
     const project = parsedUrl.searchParams.get('project') || undefined;
     const statsPeriod = parsedUrl.searchParams.get('statsPeriod') || undefined;

--- a/api/test/routes/sentry-query.test.ts
+++ b/api/test/routes/sentry-query.test.ts
@@ -352,6 +352,38 @@ describe('Sentry Query Route', () => {
       expect(response.body.endpoint).toBe('issues');
       expect(response.body.warning).toContain('Discover URLs are not fully supported');
     });
+
+    it('should strip Unicode Private Use Area characters from query', async () => {
+      // This URL contains %EF%80%8D (U+F00D) characters that Sentry UI uses for formatting
+      const response = await request(app)
+        .post('/api/sentry-query/parse-url')
+        .send({
+          url: 'https://demo.sentry.io/issues/?project=4508968134377472&query=is%3Aunresolved%20level%3A%EF%80%8DContains%EF%80%8Derror&referrer=issue-list&statsPeriod=14d',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.org).toBe('demo');
+      expect(response.body.query).toBe('is:unresolved level:Containserror');
+      expect(response.body.project).toBe('4508968134377472');
+      expect(response.body.statsPeriod).toBe('14d');
+    });
+
+    it('should handle various Unicode Private Use Area characters in query', async () => {
+      // Test with multiple PUA characters (U+E000 to U+F8FF range)
+      const response = await request(app)
+        .post('/api/sentry-query/parse-url')
+        .send({
+          url: 'https://team-se-oi.sentry.io/issues/?query=test%EE%80%80value%EF%A3%BFend',
+        })
+        .set('Content-Type', 'application/json');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      // PUA characters should be stripped, leaving just the clean text
+      expect(response.body.query).toBe('testvalueend');
+    });
   });
 
   describe('GET /api/sentry-query/properties', () => {


### PR DESCRIPTION
## Summary
- Strip Unicode Private Use Area characters (U+E000–U+F8FF) when parsing Sentry URLs in the API Query Tester
- Sentry UI embeds invisible PUA characters (e.g., U+F00D as `%EF%80%8D`) into search URLs for internal formatting, which cause display/parsing issues when pasted into the playground
- Add two test cases covering real Sentry URLs and the full PUA character range

## Test plan
- [ ] Run API tests: `docker-compose exec api npm test`
- [ ] Paste a Sentry issues URL containing PUA characters into the API Query Tester and verify the query parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)